### PR TITLE
1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iopipe/config",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "A more opinionated default IOpipe agent config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bump the version to `1.0.0` for release.
Why major `1.0.0`? 
In the meta package we currently specify `^0.3.0` as the allowed version for `@iopipe/config`
https://github.com/iopipe/iopipe-js/blob/master/package.json#L34

This means that the only automatic updates the package can receive are for `patch` level semver updates. If we publish `0.4.0`, we need to again update `@iopipe/iopipe` to `@iopipe/config@^0.4.0`.

We should support a better automatic upgrade path for fixes _and_ features. Thus, a "real" semver scheme starting at `1.0.0`. This applies to other repos as well that aren't PoC level. (trace, event-info).

See this also for an argument against `0.x.x` at all:
https://github.com/semantic-release/semantic-release/blob/caribou/docs/support/FAQ.md#can-i-set-the-initial-release-version-of-my-package-to-001 