### PR TITLE
Update trace to 1.6.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iopipe/config",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A more opinionated default IOpipe agent config",
   "main": "index.js",
   "scripts": {
@@ -19,6 +19,6 @@
   "dependencies": {
     "@iopipe/event-info": "^1.3.2",
     "@iopipe/profiler": "^2.1.2",
-    "@iopipe/trace": "^1.5.3"
+    "@iopipe/trace": "^1.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,10 +19,10 @@
     lodash.get "^4.4.2"
     simple-get "^3.0.3"
 
-"@iopipe/trace@^1.5.3":
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/@iopipe/trace/-/trace-1.5.3.tgz#eba76f485cf42774b9b648928282e8b53d142b63"
-  integrity sha512-CkFw7wbRWtbxnbASnScBe7QW+Ng5kok+RAxMH88LnazwyBlsYMlLU4BjVLIMVqmDlRu6idjOBaueJaLkeSYIxw==
+"@iopipe/trace@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@iopipe/trace/-/trace-1.6.0.tgz#69ecbd94b84397481107fa23d2d5ea3ad5bf7b11"
+  integrity sha512-nprhHCV7uwOHo3pL9jpRkM02jCRUEAoJr1qCmCaGyRkJdOQxqDB51K1p/Q//xJrEmOexM9u4EZprUMdqzXrDkg==
   dependencies:
     flat "^4.0.0"
     isarray "^2.0.4"


### PR DESCRIPTION
Update trace to 1.6.0 (MongoDB auto-trace)
Bump version to 1.4.4
Update yarn.lock