### PR TITLE
Restore CircleCI test_build_deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,8 @@ workflows:
       - deploy:
           filters:
             branches:
-              ignore: /.*/
+              only:
+                - master
             tags:
               only:
                 - /v[0-9]+(\.[0-9]+)*/


### PR DESCRIPTION
CircleCI config seemed to be set up to ignore all branches.  This specifies master as the target branch, so let's see if that helps.